### PR TITLE
Fix query overwrite with execute

### DIFF
--- a/Datagrid/PropelDatagrid.php
+++ b/Datagrid/PropelDatagrid.php
@@ -93,7 +93,7 @@ abstract class PropelDatagrid implements PropelDatagridInterface
 
     public function execute()
     {
-        $this->query = $this->configureQuery();
+        $this->query = $this->query ?: $this->configureQuery();
         $this->buildForm();
 
         $this->preExecute();

--- a/Datagrid/PropelDatagrid.php
+++ b/Datagrid/PropelDatagrid.php
@@ -91,9 +91,11 @@ abstract class PropelDatagrid implements PropelDatagridInterface
         return $this;
     }
 
-    public function execute()
+    public function execute($configureQuery = true)
     {
-        $this->query = $this->query ?: $this->configureQuery();
+        if($configureQuery) {
+            $this->query = $this->configureQuery();
+        }
         $this->buildForm();
 
         $this->preExecute();


### PR DESCRIPTION
Bonjour,

lorsque l'on execute() un datagrid, les setQuery() sont overwrite par le configureQuery() dans les datagrids.

Pouvez vous me confirmer que tout est bon pour vous s'il vous plaît ?